### PR TITLE
activate drift checks for documents

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -17,4 +17,4 @@ description: |-
 
 ### Required
 
-- **profile** (String) SORACOM Profile
+- `profile` (String) SORACOM Profile

--- a/docs/resources/credentials.md
+++ b/docs/resources/credentials.md
@@ -17,13 +17,13 @@ description: |-
 
 ### Required
 
-- **credentials** (Map of String)
-- **credentials_id** (String)
-- **description** (String)
-- **type** (String)
+- `credentials` (Map of String)
+- `credentials_id` (String)
+- `description` (String)
+- `type` (String)
 
-### Optional
+### Read-Only
 
-- **id** (String) The ID of this resource.
+- `id` (String) The ID of this resource.
 
 

--- a/docs/resources/eventhandler_handlers.md
+++ b/docs/resources/eventhandler_handlers.md
@@ -17,56 +17,59 @@ description: |-
 
 ### Required
 
-- **action_config_list** (Block Set, Min: 1) (see [below for nested schema](#nestedblock--action_config_list))
-- **name** (String)
-- **rule_config** (Block List, Min: 1, Max: 1) (see [below for nested schema](#nestedblock--rule_config))
-- **status** (String)
+- `action_config_list` (Block Set, Min: 1) (see [below for nested schema](#nestedblock--action_config_list))
+- `name` (String)
+- `rule_config` (Block List, Min: 1, Max: 1) (see [below for nested schema](#nestedblock--rule_config))
+- `status` (String)
 
 ### Optional
 
-- **description** (String)
-- **id** (String) The ID of this resource.
-- **target_group_id** (String)
-- **target_imsi** (String)
-- **target_operator_id** (String)
-- **target_sim_id** (String)
+- `description` (String)
+- `target_group_id` (String)
+- `target_imsi` (String)
+- `target_operator_id` (String)
+- `target_sim_id` (String)
+
+### Read-Only
+
+- `id` (String) The ID of this resource.
 
 <a id="nestedblock--action_config_list"></a>
 ### Nested Schema for `action_config_list`
 
 Required:
 
-- **properties** (Block List, Min: 1, Max: 1) (see [below for nested schema](#nestedblock--action_config_list--properties))
-- **type** (String)
+- `properties` (Block List, Min: 1, Max: 1) (see [below for nested schema](#nestedblock--action_config_list--properties))
+- `type` (String)
 
 <a id="nestedblock--action_config_list--properties"></a>
 ### Nested Schema for `action_config_list.properties`
 
 Required:
 
-- **execution_date_time_const** (String)
+- `execution_date_time_const` (String)
 
 Optional:
 
-- **access_key** (String)
-- **body** (String)
-- **content_type** (String)
-- **endpoint** (String)
-- **execution_offset_minutes** (String)
-- **function_name** (String)
-- **headers** (Map of String)
-- **http_method** (String)
-- **message** (String)
-- **parameter1** (String)
-- **parameter2** (String)
-- **parameter3** (String)
-- **parameter4** (String)
-- **parameter5** (String)
-- **secret_access_key** (String)
-- **speed_class** (String)
-- **title** (String)
-- **to** (String)
-- **url** (String)
+- `access_key` (String)
+- `body` (String)
+- `content_type` (String)
+- `endpoint` (String)
+- `execution_offset_minutes` (String)
+- `function_name` (String)
+- `headers` (Map of String)
+- `http_method` (String)
+- `message` (String)
+- `parameter1` (String)
+- `parameter2` (String)
+- `parameter3` (String)
+- `parameter4` (String)
+- `parameter5` (String)
+- `secret_access_key` (String)
+- `speed_class` (String)
+- `title` (String)
+- `to` (String)
+- `url` (String)
 
 
 
@@ -75,24 +78,24 @@ Optional:
 
 Required:
 
-- **properties** (Block List, Min: 1, Max: 1) (see [below for nested schema](#nestedblock--rule_config--properties))
-- **type** (String)
+- `properties` (Block List, Min: 1, Max: 1) (see [below for nested schema](#nestedblock--rule_config--properties))
+- `type` (String)
 
 <a id="nestedblock--rule_config--properties"></a>
 ### Nested Schema for `rule_config.properties`
 
 Required:
 
-- **inactive_timeout_date_const** (String)
+- `inactive_timeout_date_const` (String)
 
 Optional:
 
-- **inactive_timeout_offset_minutes** (String)
-- **limit_total_amount** (String)
-- **limit_total_traffic_mega_byte** (String)
-- **run_once_among_target** (Boolean)
-- **target_ota_status** (String)
-- **target_speed_class** (String)
-- **target_status** (String)
+- `inactive_timeout_offset_minutes` (String)
+- `limit_total_amount` (String)
+- `limit_total_traffic_mega_byte` (String)
+- `run_once_among_target` (Boolean)
+- `target_ota_status` (String)
+- `target_speed_class` (String)
+- `target_status` (String)
 
 

--- a/docs/resources/group.md
+++ b/docs/resources/group.md
@@ -17,10 +17,10 @@ description: |-
 
 ### Required
 
-- **tags** (Map of String) Tags for group to be created.
+- `tags` (Map of String) Tags for group to be created.
 
-### Optional
+### Read-Only
 
-- **id** (String) The ID of this resource.
+- `id` (String) The ID of this resource.
 
 

--- a/docs/resources/group_configuration_air.md
+++ b/docs/resources/group_configuration_air.md
@@ -17,23 +17,26 @@ description: |-
 
 ### Required
 
-- **group_id** (String)
+- `group_id` (String)
 
 ### Optional
 
-- **dns_servers** (List of String)
-- **id** (String) The ID of this resource.
-- **meta_data** (Block List, Max: 1) (see [below for nested schema](#nestedblock--meta_data))
-- **use_custom_dns** (Boolean)
-- **user_data** (String)
+- `dns_servers` (List of String)
+- `meta_data` (Block List, Max: 1) (see [below for nested schema](#nestedblock--meta_data))
+- `use_custom_dns` (Boolean)
+- `user_data` (String)
+
+### Read-Only
+
+- `id` (String) The ID of this resource.
 
 <a id="nestedblock--meta_data"></a>
 ### Nested Schema for `meta_data`
 
 Optional:
 
-- **allow_origin** (String)
-- **enabled** (Boolean)
-- **read_only** (Boolean)
+- `allow_origin` (String)
+- `enabled` (Boolean)
+- `read_only` (Boolean)
 
 

--- a/docs/resources/group_configuration_funk.md
+++ b/docs/resources/group_configuration_funk.md
@@ -17,23 +17,23 @@ description: |-
 
 ### Required
 
-- **content_type** (String)
-- **credentials_id** (String)
-- **destination** (Block List, Min: 1, Max: 1) (see [below for nested schema](#nestedblock--destination))
-- **enabled** (Boolean)
-- **group_id** (String)
+- `content_type` (String)
+- `credentials_id` (String)
+- `destination` (Block List, Min: 1, Max: 1) (see [below for nested schema](#nestedblock--destination))
+- `enabled` (Boolean)
+- `group_id` (String)
 
-### Optional
+### Read-Only
 
-- **id** (String) The ID of this resource.
+- `id` (String) The ID of this resource.
 
 <a id="nestedblock--destination"></a>
 ### Nested Schema for `destination`
 
 Required:
 
-- **provider** (String)
-- **resource_url** (String)
-- **service** (String)
+- `provider` (String)
+- `resource_url` (String)
+- `service` (String)
 
 

--- a/docs/resources/group_configuration_funnel.md
+++ b/docs/resources/group_configuration_funnel.md
@@ -17,24 +17,27 @@ description: |-
 
 ### Required
 
-- **content_type** (String) content_type
-- **credentials_id** (String) credentials_id
-- **destination** (Block List, Min: 1, Max: 1) destination (see [below for nested schema](#nestedblock--destination))
-- **enabled** (Boolean) Flag for the configuration status.
-- **group_id** (String) Target group.
+- `content_type` (String) content_type
+- `credentials_id` (String) credentials_id
+- `destination` (Block List, Min: 1, Max: 1) destination (see [below for nested schema](#nestedblock--destination))
+- `enabled` (Boolean) Flag for the configuration status.
+- `group_id` (String) Target group.
 
 ### Optional
 
-- **add_sim_id** (Boolean) add_sim_id
-- **id** (String) The ID of this resource.
+- `add_sim_id` (Boolean) add_sim_id
+
+### Read-Only
+
+- `id` (String) The ID of this resource.
 
 <a id="nestedblock--destination"></a>
 ### Nested Schema for `destination`
 
 Required:
 
-- **provider** (String) provider
-- **resource_url** (String) resource_url
-- **service** (String) service
+- `provider` (String) provider
+- `resource_url` (String) resource_url
+- `service` (String) service
 
 

--- a/docs/resources/role.md
+++ b/docs/resources/role.md
@@ -17,13 +17,13 @@ description: |-
 
 ### Required
 
-- **description** (String)
-- **operator_id** (String)
-- **permission** (String)
-- **role_id** (String)
+- `description` (String)
+- `operator_id` (String)
+- `permission` (String)
+- `role_id` (String)
 
-### Optional
+### Read-Only
 
-- **id** (String) The ID of this resource.
+- `id` (String) The ID of this resource.
 
 

--- a/docs/resources/role_attachment.md
+++ b/docs/resources/role_attachment.md
@@ -17,12 +17,12 @@ description: |-
 
 ### Required
 
-- **operator_id** (String)
-- **role_id** (String)
-- **user_name** (String)
+- `operator_id` (String)
+- `role_id` (String)
+- `user_name` (String)
 
-### Optional
+### Read-Only
 
-- **id** (String) The ID of this resource.
+- `id` (String) The ID of this resource.
 
 

--- a/docs/resources/sim_configuration_group.md
+++ b/docs/resources/sim_configuration_group.md
@@ -17,11 +17,11 @@ description: |-
 
 ### Required
 
-- **sim_group_id** (String)
-- **sim_id** (String)
+- `sim_group_id` (String)
+- `sim_id` (String)
 
-### Optional
+### Read-Only
 
-- **id** (String) The ID of this resource.
+- `id` (String) The ID of this resource.
 
 

--- a/docs/resources/sim_tags.md
+++ b/docs/resources/sim_tags.md
@@ -17,11 +17,11 @@ description: |-
 
 ### Required
 
-- **sim_id** (String)
-- **tags** (Map of String)
+- `sim_id` (String)
+- `tags` (Map of String)
 
-### Optional
+### Read-Only
 
-- **id** (String) The ID of this resource.
+- `id` (String) The ID of this resource.
 
 

--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -17,12 +17,12 @@ description: |-
 
 ### Required
 
-- **description** (String)
-- **operator_id** (String)
-- **user_name** (String)
+- `description` (String)
+- `operator_id` (String)
+- `user_name` (String)
 
-### Optional
+### Read-Only
 
-- **id** (String) The ID of this resource.
+- `id` (String) The ID of this resource.
 
 

--- a/terraform.mk
+++ b/terraform.mk
@@ -22,7 +22,7 @@ docs-diff:
 	git diff --exit-code --relative $(GENERATED_DIR)
 
 .PHONY: ci-test-docs
-ci-test-docs: install-tfplugindocs docs-generate ## ci test for documents (fixme: run `docs-diff`)
+ci-test-docs: install-tfplugindocs docs-generate docs-diff ## ci test for documents
 
 .PHONY: clear
 clear:


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

#### What this PR does / why we need it:

activate drift check on CI for documents in order to make sure that auto-generated docs are always synced with the implementations

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #18 

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

No

#### Additional documentation
