### PR TITLE
explicitly handles authentication method other than authKey

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -14,7 +14,7 @@ builds:
   flags:
     - -trimpath
   ldflags:
-    - '-s -w -X main.version={{.Version}} -X main.commit={{.Commit}}'
+    - '-s -w -X github.com/ks6088ts/terraform-provider-soracom/internal.Version={{.Version}} -X github.com/ks6088ts/terraform-provider-soracom/internal.Revision={{.Commit}}'
   goos:
     - freebsd
     - windows

--- a/internal/conns/conns.go
+++ b/internal/conns/conns.go
@@ -63,12 +63,24 @@ func getProfile(profileName string) (*profile, error) {
 		return nil, err
 	}
 
+	if err := validateProfile(&p); err != nil {
+		return nil, err
+	}
+
 	// supply default values for older versions (which support 'jp' coverage type only)
 	if p.CoverageType == "" {
 		p.CoverageType = "jp"
 	}
 
 	return &p, nil
+}
+
+func validateProfile(p *profile) error {
+	// validation logic: handles authentication methods other than auth key
+	if p.AuthKey == nil || p.AuthKeyId == nil {
+		return fmt.Errorf("authentication by auth key is only supported. please specify AuthKey and AuthKeyId in profile")
+	}
+	return nil
 }
 
 type SoracomClient struct {

--- a/internal/conns/conns_test.go
+++ b/internal/conns/conns_test.go
@@ -113,3 +113,37 @@ func TestGetProfile(t *testing.T) {
 		t.Errorf("failed to get registerPaymentMethod")
 	}
 }
+
+func TestValidateProfile(t *testing.T) {
+	tempAuthKeyId := "authKeyId"
+	tempAuthKey := "authKey"
+
+	testCases := []struct {
+		name     string
+		profile  profile
+		hasError bool
+	}{
+		{
+			name: "nominal scenarios with authKey specified in profile",
+			profile: profile{
+				AuthKeyId: &tempAuthKeyId,
+				AuthKey:   &tempAuthKey,
+			},
+			hasError: false,
+		},
+		{
+			name:     "non-nominal scenarios without authKey in profile",
+			profile:  profile{},
+			hasError: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			err := validateProfile(&testCase.profile)
+			if hasError := (err != nil); hasError != testCase.hasError {
+				t.Errorf("got %v, expected %v, err %v", hasError, testCase.hasError, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

#### What this PR does / why we need it:

To state authentication method other than authKey is not supported explicitly, validate profile before calling `/auth` API

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #28 

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

No

#### Additional documentation

We can reproduce the issue as follows.

```bash
cd examples/group
# install provider via terraform registry
terraform init
terraform plan
╷
│ Error: Unable to create SORACOM API client @ Revision=, Version=
│
│   with provider["registry.terraform.io/ks6088ts/soracom"],
│   on main.tf line 9, in provider "soracom":
│    9: provider "soracom" {
│
│ Unable to create SORACOM API client, 400 Bad Request
╵
```

After applying the patch, validation error is dumped
```bash
# generate provider in local
make build
cd examples/group
# install local provider applied with the patch
terraform init -plugin-dir=../../plugins
terraform plan
╷
│ Error: Unable to create SORACOM API client @ Revision=88067cb, Version=0.0.4
│
│   with provider["registry.terraform.io/ks6088ts/soracom"],
│   on main.tf line 9, in provider "soracom":
│    9: provider "soracom" {
│
│ Unable to create SORACOM API client, authentication by auth key is only
│ supported. please specify AuthKey and AuthKeyId in profile
```